### PR TITLE
Bugfix: Handle KeyError when environment variables or config keys are missing

### DIFF
--- a/src/kthutils/cli.nw
+++ b/src/kthutils/cli.nw
@@ -132,7 +132,7 @@ try:
   username = os.environ["KTH_LOGIN"]
   password = os.environ["KTH_PASSWD"]
   return username, password
-except:
+except KeyError:
   pass
 <<credential imports>>=
 import os
@@ -147,8 +147,10 @@ try:
   username = config.get("credentials.username")
   password = config.get("credentials.password")
   return username, password
-except:
+except KeyError:
   pass
+<<imports>>=
+import typerconf as config
 @
 
 \subsection{Instruct user about credentials}


### PR DESCRIPTION
The import of the config was missing. When the exception caught
everything, we didn't get an error that config didn't exist.

Thanks, Emma Riese, for finding it!
