### PR TITLE
add labweek2026

### DIFF
--- a/src/kthutils/forms.nw
+++ b/src/kthutils/forms.nw
@@ -787,8 +787,21 @@ kthutils config forms.rewriter.restlabb -s ""
 @
 
 We then want to have the overall format string.
+The lab week form (\cref{LabWeekRewriter}) reports results for the same
+courses in the same way; only the columns the fields live in differ.
+We therefore lift the body of the format string into its own chunk,
+[[<<rewriter format string body>>]], so both rewriters share a single
+definition and cannot drift apart when we tweak the reporting commands.
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.format_string -s "
+<<rewriter format string body>>
+"
+@
+
+The body echoes the parsed fields for the log, then---unless the grader
+already reported the result in Canvas---runs [[canvaslms grade]], and
+finally reports the aggregated result to Ladok.
+<<rewriter format string body>>=
 echo 'Time:         {time}'
 echo 'Course:       {course}'
 echo 'Module:       {module}'
@@ -820,7 +833,6 @@ canvaslms results \\
 | sed -E 's/ ?[HV]T[0-9]{{2}}( \(.*\))?//' \\
 | ladok report -fv
 echo
-"
 @
 
 Now we need to define the substitutions used in the format string above.
@@ -838,7 +850,10 @@ filter out the course code in particular.
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.substitutions.course_code.column -s 3
 kthutils config forms.rewriter.restlabb.substitutions.course_code.regex \
-  -s "s/^.*([A-Z]{2}\d{3,4}[A-Z]?).*$/\1/"
+  -s "<<course code regex>>"
+@ The regex itself is the same for both forms, so we name it for reuse.
+<<course code regex>>=
+s/^.*([A-Z]{2}\d{3,4}[A-Z]?).*$/\1/
 @
 
 We also want to extract the semester from that column, and turn it into 
@@ -847,10 +862,13 @@ We give a list of rewrites, one for each semester.
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.substitutions.semester.column -s 3
 kthutils config forms.rewriter.restlabb.substitutions.semester.regex \
-  -s "s/^.*[Hh][Tt](\d{2}).*$/HT\1/" \
-  -s "s/^.*[Vv][Tt](\d{2}).*$/VT\1/"
-@ We used two regexes to ensure that we rewrite both HT and VT to the correct 
+  <<semester regexes>>
+@ We used two regexes to ensure that we rewrite both HT and VT to the correct
 case.
+<<semester regexes>>=
+-s "s/^.*[Hh][Tt](\d{2}).*$/HT\1/" \
+-s "s/^.*[Vv][Tt](\d{2}).*$/VT\1/"
+@
 
 However, we can do a bit better.
 We can actually rewrite to the normal nicknames that we use for the courses:
@@ -863,8 +881,11 @@ course.
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.substitutions.course_nick.column -s 3
 kthutils config forms.rewriter.restlabb.substitutions.course_nick.regex \
-  -s "s/^.*DD1310.*(CMAST|[SC]ITEH?)?.*$/prgm/" \
-  -s "s/^.*DD131[57].*(prgi)?.*$/prgi/"
+  <<course nick regexes>>
+@
+<<course nick regexes>>=
+-s "s/^.*DD1310.*(CMAST|[SC]ITEH?)?.*$/prgm/" \
+-s "s/^.*DD131[57].*(prgi)?.*$/prgi/"
 @
 
 Now, let's turn to that year.
@@ -874,7 +895,10 @@ However, some TAs write HT24 (most), some HT2024 (Edvin).
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.substitutions.year.column -s 3
 kthutils config forms.rewriter.restlabb.substitutions.year.regex \
-  -s "s/^.*([HhVv][Tt][- ]*|prg[im])(?:20)?(\d{2}).*$/\2/"
+  -s "<<year regex>>"
+@
+<<year regex>>=
+s/^.*([HhVv][Tt][- ]*|prg[im])(?:20)?(\d{2}).*$/\2/
 @
 
 We also want to extract the grader, or rather, the grader's (KTH) email.
@@ -882,10 +906,15 @@ The same for the student.
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.substitutions.grader.column -s 11
 kthutils config forms.rewriter.restlabb.substitutions.grader.regex \
-  -s "s/^.*?([A-Za-z0-9]+@kth.se).* $/\1/"
+  -s "<<grader email regex>>"
 kthutils config forms.rewriter.restlabb.substitutions.student.column -s 2
 kthutils config forms.rewriter.restlabb.substitutions.student.regex \
   -s "s/^.*?([A-Za-z0-9]+@kth.se).*$/\1/"
+@ The grader's address sits last on its line, so we anchor on a trailing
+space.  We reuse this for the lab week form, whose grader column is the
+same kind of field.
+<<grader email regex>>=
+s/^.*?([A-Za-z0-9]+@kth.se).* $/\1/
 @
 
 Also, we want to extract if the grader already put the result into Canvas or 
@@ -902,8 +931,11 @@ We try to extract the grade from that.
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.substitutions.grade.column -s 5
 kthutils config forms.rewriter.restlabb.substitutions.grade.regex \
-  -s "s/.*([Bb]etyg|,)?\b([A-F])(\b.*)?$/\2/" \
-  -s "s/.*(EJ GODKÄN[TD]|[Ee]j godkän[dt]).*$/F/"
+  <<grade regexes>>
+@
+<<grade regexes>>=
+-s "s/.*([Bb]etyg|,)?\b([A-F])(\b.*)?$/\2/" \
+-s "s/.*(EJ GODKÄN[TD]|[Ee]j godkän[dt]).*$/F/"
 @ For P/F assignments, the TAs usually don't write any grade.
 They just write ``granskning''.
 For this, we have a default grade, in case the substitution doesn't match 
@@ -924,13 +956,19 @@ We use a negative lookahead assertion for this ([[(?!...)]]).
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.substitutions.assignment.column -s 5
 kthutils config forms.rewriter.restlabb.substitutions.assignment.regex \
-  -s 's/.*[Pp](.?[Uu]ppgift|rojekt)[s ]?(?![sg]).*/Projektredovisning/' \
-  -s 's/.*[Ss][Pp][Ee][Cc].*/Projektspec/' \
-  -s 's/.*[Gg](ransk|RANSK).*/Projektgranskning/' \
-  <<regexes for labs>>
+  <<assignment name regexes>>
 @ We used to match on only `spec`, `granskn` and `redovisn`.
 But now the `granskning` will also match `kamratgranskning` in the lab titles.
 So we'd better be more specific.
+We collect the project-related matches and the lab matches
+([[<<regexes for labs>>]]) into one named chunk so the lab week form can
+reuse exactly the same assignment names.
+<<assignment name regexes>>=
+-s 's/.*[Pp](.?[Uu]ppgift|rojekt)[s ]?(?![sg]).*/Projektredovisning/' \
+-s 's/.*[Ss][Pp][Ee][Cc].*/Projektspec/' \
+-s 's/.*[Gg](ransk|RANSK).*/Projektgranskning/' \
+<<regexes for labs>>
+@
 
 The labs are a bit more tricky.
 Here the TAs usually write something like ``Labb 3'' or ``Lab 3''.
@@ -991,11 +1029,100 @@ assignments to LAB3.
 <<restlabbsetup.sh>>=
 kthutils config forms.rewriter.restlabb.substitutions.assignment_group.column -s 5
 kthutils config forms.rewriter.restlabb.substitutions.assignment_group.regex \
-  -s "s/.*[Ll]ab(b|oration).*/LAB1/" \
-  -s "s/.*[Pp]-?(upp(gift)?|UPP(GIFT)?|rojekt|ROJEKT).*/LAB3/" \
-  -s "s/.*[Ss][Pp][Ee][Cc].*/LAB3/" \
-  -s "s/.*[Gg](ransk|RANSK).*/LAB3/" \
-  -s "s/.*[Rr](edovisn|EDOVISN).*/LAB3/"
+  <<assignment group regexes>>
+@
+<<assignment group regexes>>=
+-s "s/.*[Ll]ab(b|oration).*/LAB1/" \
+-s "s/.*[Pp]-?(upp(gift)?|UPP(GIFT)?|rojekt|ROJEKT).*/LAB3/" \
+-s "s/.*[Ss][Pp][Ee][Cc].*/LAB3/" \
+-s "s/.*[Gg](ransk|RANSK).*/LAB3/" \
+-s "s/.*[Rr](edovisn|EDOVISN).*/LAB3/"
+@
+
+\subsection{A rewriter for the lab week form}
+\label{LabWeekRewriter}
+
+Each June we also run a \emph{lab week}, recording results in a separate KTH
+Form that we always name [[labweek<YEAR>]] (e.g.\ [[labweek2026]]).
+It reports results for the same courses in the same way as Restlabb, so it
+reuses the same format string and the same regexes.
+Only two things differ, and both follow from the form's layout.
+
+First, the columns sit in different positions.
+The lab week form lets a pair of students redovisa together, so on top of the
+Restlabb columns it adds a \enquote{two students?} question and three
+[[Student 2]] columns early on.
+This shifts every later field: the course moves from column~3 to~8, the
+module from~5 to~10, the comments to~11, the \enquote{in Canvas?} flag to~12,
+and the grader's e-mail to~16.
+
+Second, when two students present together, both must be graded.
+The [[canvaslms]] commands take a \emph{regex} for the user
+([[-u '{student}']]), so it suffices to turn the two students into one
+alternation, [[(first@kth.se|second@kth.se)]], and a single grade command
+covers both.
+We get this for free from the substitution engine: a slice column [[3:7:3]]
+picks columns~3 and~6 (the two kth-mail columns), and a list of two
+regexes---one extracting the first address, one the second---is joined into a
+parenthesised alternation when both match (and left as a bare address when
+only the first does).
+
+We clear any previous configuration first, in case we re-run these lines after
+an update.
+<<restlabbsetup.sh>>=
+kthutils config forms.rewriter.labweek -s ""
+kthutils config forms.rewriter.labweek.format_string -s "
+<<rewriter format string body>>
+"
+@
+
+The verbatim columns and the shared regexes only differ from Restlabb in their
+column numbers.
+<<restlabbsetup.sh>>=
+kthutils config forms.rewriter.labweek.substitutions.time.column -s 0
+kthutils config forms.rewriter.labweek.substitutions.module.column -s 10
+kthutils config forms.rewriter.labweek.substitutions.comments.column -s 11
+kthutils config forms.rewriter.labweek.substitutions.course.column -s 8
+kthutils config forms.rewriter.labweek.substitutions.course_code.column -s 8
+kthutils config forms.rewriter.labweek.substitutions.course_code.regex \
+  -s "<<course code regex>>"
+kthutils config forms.rewriter.labweek.substitutions.semester.column -s 8
+kthutils config forms.rewriter.labweek.substitutions.semester.regex \
+  <<semester regexes>>
+kthutils config forms.rewriter.labweek.substitutions.course_nick.column -s 8
+kthutils config forms.rewriter.labweek.substitutions.course_nick.regex \
+  <<course nick regexes>>
+kthutils config forms.rewriter.labweek.substitutions.year.column -s 8
+kthutils config forms.rewriter.labweek.substitutions.year.regex \
+  -s "<<year regex>>"
+kthutils config forms.rewriter.labweek.substitutions.in_canvas.column -s 12
+kthutils config forms.rewriter.labweek.substitutions.grade.column -s 10
+kthutils config forms.rewriter.labweek.substitutions.grade.regex \
+  <<grade regexes>>
+kthutils config forms.rewriter.labweek.substitutions.grade.no_match_default \
+  -s P
+kthutils config forms.rewriter.labweek.substitutions.assignment.column -s 10
+kthutils config forms.rewriter.labweek.substitutions.assignment.regex \
+  <<assignment name regexes>>
+kthutils config forms.rewriter.labweek.substitutions.assignment_group.column -s 10
+kthutils config forms.rewriter.labweek.substitutions.assignment_group.regex \
+  <<assignment group regexes>>
+kthutils config forms.rewriter.labweek.substitutions.grader.column -s 16
+kthutils config forms.rewriter.labweek.substitutions.grader.regex \
+  -s "<<grader email regex>>"
+@
+
+The student substitution is the one place the lab week form needs its own
+regexes.
+Column [[3:7:3]] joins the two kth-mail columns with a tab; the first regex
+extracts the leading address, the second extracts an address that follows a
+[[@kth.se]] and a tab---so it only matches, and only contributes a second
+alternative, when a second student is present.
+<<restlabbsetup.sh>>=
+kthutils config forms.rewriter.labweek.substitutions.student.column -s "3:7:3"
+kthutils config forms.rewriter.labweek.substitutions.student.regex \
+  -s "s/^.*?([A-Za-z0-9]+@kth.se).*$/\1/" \
+  -s "s/^.*@kth.se\t.*?([A-Za-z0-9]+@kth.se).*$/\1/"
 @
 
 \subsection{The [[rewriter]] subcommands}
@@ -1053,6 +1180,25 @@ configured above (in [[restlabbsetup.sh>>]]).
 kthutils forms next restlabb${AC_YEAR} \
 | grep -E "(Bosk|DD131[57].*[CS]INEK)" \
 | kthutils forms rewriter rewrite restlabb
+@
+
+During the June lab week we run the same pipeline for the lab week form
+(\cref{LabWeekRewriter}).
+That form is always named [[labweek<YEAR>]] with the \emph{full} year---unlike
+the academic year above, so we take [[date +%Y]] rather than the two-digit
+[[YEAR]].
+Since the form only exists during and after the lab week, we guard on its
+presence in the configuration (an exact match against [[forms ls]]); outside
+that window, or before we have added the form, this is simply a no-op.
+We filter and rewrite exactly as for Restlabb, but with the [[labweek]]
+rewriter.
+<<restlabb.sh>>=
+LABWEEK="labweek$(date +%Y)"
+if kthutils forms ls | grep -qx "${LABWEEK}"; then
+  kthutils forms next "${LABWEEK}" \
+  | grep -E "(Bosk|DD131[57].*[CS]INEK)" \
+  | kthutils forms rewriter rewrite labweek
+fi
 @
 
 
@@ -1285,6 +1431,33 @@ def test_rewrite_row_column_slice():
   }
   result = kthutils.forms.rewrite_row(row, rewriter)
   assert result == "Range: col1\tcol2"
+@
+
+The lab week rewriter (\cref{LabWeekRewriter}) relies on a stepped slice and a
+list of regexes to merge a pair of students into one [[-u]] alternation.
+Let's verify that two students collapse into [[(first|second)]] while a single
+student is left as a bare address.
+<<test functions>>=
+def test_rewrite_row_two_students():
+  student = {
+    "column": "3:7:3",
+    "regex": [
+      r"s/^.*?([A-Za-z0-9]+@kth.se).*$/\1/",
+      r"s/^.*@kth.se\t.*?([A-Za-z0-9]+@kth.se).*$/\1/"
+    ]
+  }
+  rewriter = {"format_string": "-u {student}",
+              "substitutions": {"student": student}}
+
+  # Two students presenting together: cols 3 and 6 hold the kth-mails.
+  two = ["t", "Ja", "Anna A", "anna@kth.se", "p1",
+         "Bo B", "bob@kth.se", "p2"]
+  assert kthutils.forms.rewrite_row(two, rewriter) \
+    == "-u (anna@kth.se|bob@kth.se)"
+
+  # A single student leaves the Student 2 columns empty.
+  one = ["t", "Nej", "Anna A", "anna@kth.se", "p1", "", "", ""]
+  assert kthutils.forms.rewrite_row(one, rewriter) == "-u anna@kth.se"
 @
 
 The [[rewriter]] that we get will have the following form.


### PR DESCRIPTION
- **Splits publish target**
- **Add OneDrive file commands**
- **Fix OneDrive SharePoint auth trigger**
- **Add msal dependency**
- **Add OneDrive auth debug logging**
- **Add global CLI logging verbosity**
- **Handle SharePoint Azure AD login**
- **List shared OneDrive folders**
- **Add OneDrive base URL support**
- **Extend SharePoint URL support and browsing**
- **Add labweek rewriter and run it from the Restlabb cron pipeline**
